### PR TITLE
rw - fix publish storybook to pages action for QA repo

### DIFF
--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -19,11 +19,11 @@ jobs:
           mkdir -p storybook-static
           npm run build-storybook
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@4.2.0
+        uses: JamesIves/github-pages-deploy-action@v4.2.2
         with:
           repository-name: ${{ github.repository }}-docs-qa
           token: ${{ secrets.TOKEN }}
-          branch: main # The branch the action should deploy to.
+          branch: gh-pages # The branch the action should deploy to.
           folder: frontend/storybook-static # The folder that the build-storybook script generates files.
           clean: true # Automatically remove deleted files from the deploy branch
           target-folder: docs/storybook # The folder that we serve our Storybook files from 


### PR DESCRIPTION
(Opening a pr so the action will correctly trigger)

- github-pages-deploy-action v4.2 -> v4.2.2
- changed target branch in docs repo to gh-pages rather than main